### PR TITLE
It's always better to unregister handlers 

### DIFF
--- a/chapter-04/end/MainGame.cs
+++ b/chapter-04/end/MainGame.cs
@@ -101,7 +101,12 @@ namespace chapter_04
 
         private void SwitchGameState(BaseGameState gameState)
         {
-            _currentGameState?.UnloadContent(Content);
+            if (_currentGameState != null)
+            {
+                _currentGameState.OnStateSwitched -= CurrentGameState_OnStateSwitched;
+                _currentGameState.OnEventNotification -= _currentGameState_OnEventNotification;
+                _currentGameState.UnloadContent(Content);
+            }
 
             _currentGameState = gameState;
 

--- a/chapter-05/end/MainGame.cs
+++ b/chapter-05/end/MainGame.cs
@@ -101,7 +101,12 @@ namespace chapter_05
 
         private void SwitchGameState(BaseGameState gameState)
         {
-            _currentGameState?.UnloadContent();
+            if (_currentGameState != null)
+            {
+                _currentGameState.OnStateSwitched -= CurrentGameState_OnStateSwitched;
+                _currentGameState.OnEventNotification -= _currentGameState_OnEventNotification;
+                _currentGameState.UnloadContent();
+            }
 
             _currentGameState = gameState;
 


### PR DESCRIPTION
so old game states stop responding to events. No a problem in chapter 4 or 5, but it might become one later.