### PR TITLE
Add sound manager and refactorings

### DIFF
--- a/chapter-07/wip/Engine/Input/BaseInputCommand.cs
+++ b/chapter-07/wip/Engine/Input/BaseInputCommand.cs
@@ -1,4 +1,4 @@
-﻿namespace chapter_07.Input.Base
+﻿namespace chapter_07.Engine.Input
 {
     public class BaseInputCommand { }
 }

--- a/chapter-07/wip/Engine/Input/BaseInputMapper.cs
+++ b/chapter-07/wip/Engine/Input/BaseInputMapper.cs
@@ -1,8 +1,7 @@
 ﻿using Microsoft.Xna.Framework.Input;
-using Microsoft.Xna.Framework.Input.Touch;
 using System.Collections.Generic;
 
-namespace chapter_07.Input.Base
+namespace chapter_07.Engine.Input
 {
     public class BaseInputMapper
     {

--- a/chapter-07/wip/Engine/Input/InputManager.cs
+++ b/chapter-07/wip/Engine/Input/InputManager.cs
@@ -1,8 +1,7 @@
 ﻿using Microsoft.Xna.Framework.Input;
 using System;
-using System.Collections.Generic;
 
-namespace chapter_07.Input.Base
+namespace chapter_07.Engine.Input
 {
     public class InputManager
     {

--- a/chapter-07/wip/Engine/MainGame.cs
+++ b/chapter-07/wip/Engine/MainGame.cs
@@ -1,11 +1,10 @@
-﻿using chapter_07.Enum;
+﻿using chapter_07.Engine.States;
 using chapter_07.States;
-using chapter_07.States.Base;
 
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
-namespace chapter_07
+namespace chapter_07.Engine
 {
     /// <summary>
     /// This is the main type for your game.
@@ -20,21 +19,26 @@ namespace chapter_07
         private RenderTarget2D _renderTarget;
         private Rectangle _renderScaleRectangle;
 
-        private const int DESIGNED_RESOLUTION_WIDTH = 1280;
-        private const int DESIGNED_RESOLUTION_HEIGHT = 720;
+        private int _DesignedResolutinWidth;
+        private int _DesignedResolutionHeight;
+        private float _designedResolutionAspectRatio;
 
-        private const float DESIGNED_RESOLUTION_ASPECT_RATIO = DESIGNED_RESOLUTION_WIDTH / (float)DESIGNED_RESOLUTION_HEIGHT;
+        private BaseGameState _firstGameState;
 
-        public MainGame()
+        public MainGame(int width, int height, BaseGameState firstGameState)
         {
+            Content.RootDirectory = "Content";
             graphics = new GraphicsDeviceManager(this)
             {
-                PreferredBackBufferWidth = DESIGNED_RESOLUTION_WIDTH,
-                PreferredBackBufferHeight = DESIGNED_RESOLUTION_HEIGHT,
+                PreferredBackBufferWidth = width,
+                PreferredBackBufferHeight = height,
                 IsFullScreen = false
             };
 
-            Content.RootDirectory = "Content";
+            _firstGameState = firstGameState;
+            _DesignedResolutinWidth = width;
+            _DesignedResolutionHeight = height;
+            _designedResolutionAspectRatio = width / (float)height;
         }
 
         /// <summary>
@@ -45,7 +49,7 @@ namespace chapter_07
         /// </summary>
         protected override void Initialize()
         {
-            _renderTarget = new RenderTarget2D(graphics.GraphicsDevice, DESIGNED_RESOLUTION_WIDTH, DESIGNED_RESOLUTION_HEIGHT, false,
+            _renderTarget = new RenderTarget2D(graphics.GraphicsDevice, _DesignedResolutinWidth, _DesignedResolutionHeight, false,
                 SurfaceFormat.Color, DepthFormat.None, 0, RenderTargetUsage.DiscardContents);
 
             _renderScaleRectangle = GetScaleRectangle();
@@ -64,16 +68,16 @@ namespace chapter_07
 
             Rectangle scaleRectangle;
 
-            if (actualAspectRatio <= DESIGNED_RESOLUTION_ASPECT_RATIO)
+            if (actualAspectRatio <= _designedResolutionAspectRatio)
             {
-                var presentHeight = (int)(Window.ClientBounds.Width / DESIGNED_RESOLUTION_ASPECT_RATIO + variance);
+                var presentHeight = (int)(Window.ClientBounds.Width / _designedResolutionAspectRatio + variance);
                 var barHeight = (Window.ClientBounds.Height - presentHeight) / 2;
 
                 scaleRectangle = new Rectangle(0, barHeight, Window.ClientBounds.Width, presentHeight);
             }
             else
             {
-                var presentWidth = (int)(Window.ClientBounds.Height * DESIGNED_RESOLUTION_ASPECT_RATIO + variance);
+                var presentWidth = (int)(Window.ClientBounds.Height * _designedResolutionAspectRatio + variance);
                 var barWidth = (Window.ClientBounds.Width - presentWidth) / 2;
 
                 scaleRectangle = new Rectangle(barWidth, 0, presentWidth, Window.ClientBounds.Height);
@@ -91,7 +95,7 @@ namespace chapter_07
             // Create a new SpriteBatch, which can be used to draw textures.
             spriteBatch = new SpriteBatch(GraphicsDevice);
 
-            SwitchGameState(new SplashState());
+            SwitchGameState(_firstGameState);
         }
 
         private void CurrentGameState_OnStateSwitched(object sender, BaseGameState e)
@@ -118,11 +122,11 @@ namespace chapter_07
             _currentGameState.OnEventNotification += _currentGameState_OnEventNotification;
         }
 
-        private void _currentGameState_OnEventNotification(object sender, Enum.Events e)
+        private void _currentGameState_OnEventNotification(object sender, BaseGameStateEvent e)
         {
             switch (e)
             {
-                case Events.GAME_QUIT:
+                case BaseGameStateEvent.GameQuit _:
                     Exit();
                     break;
             }

--- a/chapter-07/wip/Engine/Objects/BaseGameObject.cs
+++ b/chapter-07/wip/Engine/Objects/BaseGameObject.cs
@@ -19,7 +19,7 @@ namespace chapter_07.Engine.Objects
             set { _position = value; } 
         }
 
-        public virtual void OnNotify(BaseGameStateEvent eventType, object argument = null) { }
+        public virtual void OnNotify(BaseGameStateEvent gameEvent) { }
 
         public virtual void Render(SpriteBatch spriteBatch)
         {

--- a/chapter-07/wip/Engine/Objects/BaseGameObject.cs
+++ b/chapter-07/wip/Engine/Objects/BaseGameObject.cs
@@ -1,8 +1,8 @@
-﻿using chapter_07.Enum;
+﻿using chapter_07.Engine.States;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
-namespace chapter_07.Objects.Base
+namespace chapter_07.Engine.Objects
 {
     public class BaseGameObject
     {
@@ -19,7 +19,7 @@ namespace chapter_07.Objects.Base
             set { _position = value; } 
         }
 
-        public virtual void OnNotify(Events eventType, object argument = null) { }
+        public virtual void OnNotify(BaseGameStateEvent eventType, object argument = null) { }
 
         public virtual void Render(SpriteBatch spriteBatch)
         {

--- a/chapter-07/wip/Engine/Sound/SoundManager.cs
+++ b/chapter-07/wip/Engine/Sound/SoundManager.cs
@@ -12,7 +12,7 @@ namespace chapter_07.Engine.Sound
         private List<SoundEffectInstance> _soundtracks = new List<SoundEffectInstance>();
         private Dictionary<Type, SoundEffect> _soundBank = new Dictionary<Type, SoundEffect>();
 
-        public void AddSoundtrack(List<SoundEffectInstance> tracks)
+        public void SetSoundtrack(List<SoundEffectInstance> tracks)
         {
             _soundtracks = tracks;
             _soundtrackIndex = _soundtracks.Count - 1;
@@ -31,20 +31,22 @@ namespace chapter_07.Engine.Sound
         {
             var nbTracks = _soundtracks.Count;
 
-            if (nbTracks > 0)
+            if (nbTracks <= 0)
             {
-                var currentTrack = _soundtracks[_soundtrackIndex];
-                var nextTrack = _soundtracks[(_soundtrackIndex + 1) % nbTracks];
+                return;
+            }
 
-                if (currentTrack.State == SoundState.Stopped)
+            var currentTrack = _soundtracks[_soundtrackIndex];
+            var nextTrack = _soundtracks[(_soundtrackIndex + 1) % nbTracks];
+
+            if (currentTrack.State == SoundState.Stopped)
+            {
+                nextTrack.Play();
+                _soundtrackIndex++;
+
+                if (_soundtrackIndex >= _soundtracks.Count)
                 {
-                    nextTrack.Play();
-                    _soundtrackIndex++;
-
-                    if (_soundtrackIndex >= _soundtracks.Count)
-                    {
-                        _soundtrackIndex = 0;
-                    }
+                    _soundtrackIndex = 0;
                 }
             }
         }

--- a/chapter-07/wip/Engine/Sound/SoundManager.cs
+++ b/chapter-07/wip/Engine/Sound/SoundManager.cs
@@ -1,17 +1,30 @@
-﻿using Microsoft.Xna.Framework.Audio;
+﻿using chapter_07.Engine.States;
+
+using Microsoft.Xna.Framework.Audio;
+using System;
 using System.Collections.Generic;
 
 namespace chapter_07.Engine.Sound
 {
     public class SoundManager
     {
-        private List<SoundEffectInstance> _soundtracks = new List<SoundEffectInstance>();
         private int _soundtrackIndex = -1;
+        private List<SoundEffectInstance> _soundtracks = new List<SoundEffectInstance>();
+        private Dictionary<Type, SoundEffect> _soundBank = new Dictionary<Type, SoundEffect>();
 
         public void AddSoundtrack(List<SoundEffectInstance> tracks)
         {
             _soundtracks = tracks;
             _soundtrackIndex = _soundtracks.Count - 1;
+        }
+
+        public void OnNotify(BaseGameStateEvent gameEvent) 
+        {
+            if (_soundBank.ContainsKey(gameEvent.GetType()))
+            {
+                var sound = _soundBank[gameEvent.GetType()];
+                sound.Play();
+            }
         }
 
         public void PlaySoundtrack()
@@ -34,6 +47,11 @@ namespace chapter_07.Engine.Sound
                     }
                 }
             }
+        }
+
+        public void RegisterSound(BaseGameStateEvent gameEvent, SoundEffect sound)
+        {
+            _soundBank.Add(gameEvent.GetType(), sound);
         }
     }
 }

--- a/chapter-07/wip/Engine/Sound/SoundManager.cs
+++ b/chapter-07/wip/Engine/Sound/SoundManager.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Xna.Framework.Audio;
+using System.Collections.Generic;
+
+namespace chapter_07.Engine.Sound
+{
+    public class SoundManager
+    {
+        private List<SoundEffectInstance> _soundtracks = new List<SoundEffectInstance>();
+        private int _soundtrackIndex = -1;
+
+        public void AddSoundtrack(List<SoundEffectInstance> tracks)
+        {
+            _soundtracks = tracks;
+            _soundtrackIndex = _soundtracks.Count - 1;
+        }
+
+        public void PlaySoundtrack()
+        {
+            var nbTracks = _soundtracks.Count;
+
+            if (nbTracks > 0)
+            {
+                var currentTrack = _soundtracks[_soundtrackIndex];
+                var nextTrack = _soundtracks[(_soundtrackIndex + 1) % nbTracks];
+
+                if (currentTrack.State == SoundState.Stopped)
+                {
+                    nextTrack.Play();
+                    _soundtrackIndex++;
+
+                    if (_soundtrackIndex >= _soundtracks.Count)
+                    {
+                        _soundtrackIndex = 0;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/chapter-07/wip/Engine/States/BaseGameState.cs
+++ b/chapter-07/wip/Engine/States/BaseGameState.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using chapter_07.Engine.Input;
 using chapter_07.Engine.Objects;
+using chapter_07.Engine.Sound;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Audio;
 using Microsoft.Xna.Framework.Content;
@@ -18,6 +19,7 @@ namespace chapter_07.Engine.States
         private ContentManager _contentManager;
         protected int _viewportHeight;
         protected int _viewportWidth;
+        protected SoundManager _soundManager = new SoundManager();
 
         private readonly List<BaseGameObject> _gameObjects = new List<BaseGameObject>();
 
@@ -33,8 +35,8 @@ namespace chapter_07.Engine.States
         }
 
         public abstract void LoadContent();
-        public virtual void Update(GameTime gameTime) { }
         public abstract void HandleInput(GameTime gameTime);
+        public abstract void UpdateGameState(GameTime gameTime);
 
         public event EventHandler<BaseGameState> OnStateSwitched;
         public event EventHandler<BaseGameStateEvent> OnEventNotification;
@@ -43,6 +45,12 @@ namespace chapter_07.Engine.States
         public void UnloadContent()
         {
             _contentManager.Unload();
+        }
+
+        public virtual void Update(GameTime gameTime) 
+        {
+            UpdateGameState(gameTime);
+            _soundManager.PlaySoundtrack();
         }
 
         protected Texture2D LoadTexture(string textureName)

--- a/chapter-07/wip/Engine/States/BaseGameState.cs
+++ b/chapter-07/wip/Engine/States/BaseGameState.cs
@@ -66,19 +66,16 @@ namespace chapter_07.Engine.States
             return song ?? _contentManager.Load<SoundEffect>(FallbackSong);
         }
  
-        // TODO: is argument still needed if eventType is a class?
-        protected void NotifyEvent(BaseGameStateEvent eventType, object argument = null)
+        protected void NotifyEvent(BaseGameStateEvent gameEvent)
         {
-            OnEventNotification?.Invoke(this, eventType);
+            OnEventNotification?.Invoke(this, gameEvent);
 
             foreach (var gameObject in _gameObjects)
             {
-                gameObject.OnNotify(eventType, argument);
+                gameObject.OnNotify(gameEvent);
             }
 
-            // TODO: notify _soundManager
-            // TODO change eventType from enum to a class
-            // _soundManager.OnNotify(eventType, argument);
+            _soundManager.OnNotify(gameEvent);
         }
 
         protected void SwitchState(BaseGameState gameState)

--- a/chapter-07/wip/Engine/States/BaseGameState.cs
+++ b/chapter-07/wip/Engine/States/BaseGameState.cs
@@ -1,17 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
-using chapter_07.Enum;
-using chapter_07.Input.Base;
-using chapter_07.Objects.Base;
+using chapter_07.Engine.Input;
+using chapter_07.Engine.Objects;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Audio;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Media;
 
-namespace chapter_07.States.Base
+namespace chapter_07.Engine.States
 {
     public abstract class BaseGameState
     {
@@ -40,7 +37,7 @@ namespace chapter_07.States.Base
         public abstract void HandleInput(GameTime gameTime);
 
         public event EventHandler<BaseGameState> OnStateSwitched;
-        public event EventHandler<Events> OnEventNotification;
+        public event EventHandler<BaseGameStateEvent> OnEventNotification;
         protected abstract void SetInputManager();
 
         public void UnloadContent()
@@ -61,7 +58,8 @@ namespace chapter_07.States.Base
             return song ?? _contentManager.Load<SoundEffect>(FallbackSong);
         }
  
-        protected void NotifyEvent(Events eventType, object argument = null)
+        // TODO: is argument still needed if eventType is a class?
+        protected void NotifyEvent(BaseGameStateEvent eventType, object argument = null)
         {
             OnEventNotification?.Invoke(this, eventType);
 
@@ -69,6 +67,10 @@ namespace chapter_07.States.Base
             {
                 gameObject.OnNotify(eventType, argument);
             }
+
+            // TODO: notify _soundManager
+            // TODO change eventType from enum to a class
+            // _soundManager.OnNotify(eventType, argument);
         }
 
         protected void SwitchState(BaseGameState gameState)

--- a/chapter-07/wip/Engine/States/BaseGameStateEvent.cs
+++ b/chapter-07/wip/Engine/States/BaseGameStateEvent.cs
@@ -1,0 +1,7 @@
+﻿namespace chapter_07.Engine.States
+{
+    public class BaseGameStateEvent 
+    {
+        public class GameQuit : BaseGameStateEvent { }
+    }
+}

--- a/chapter-07/wip/Enum/Events.cs
+++ b/chapter-07/wip/Enum/Events.cs
@@ -1,7 +1,0 @@
-﻿namespace chapter_07.Enum
-{
-    public enum Events
-    {
-        GAME_QUIT
-    }
-}

--- a/chapter-07/wip/Objects/BulletSprite.cs
+++ b/chapter-07/wip/Objects/BulletSprite.cs
@@ -1,4 +1,4 @@
-﻿using chapter_07.Objects.Base;
+﻿using chapter_07.Engine.Objects;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 

--- a/chapter-07/wip/Objects/PlayerSprite.cs
+++ b/chapter-07/wip/Objects/PlayerSprite.cs
@@ -1,4 +1,4 @@
-﻿using chapter_07.Objects.Base;
+﻿using chapter_07.Engine.Objects;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 

--- a/chapter-07/wip/Objects/SplashImage.cs
+++ b/chapter-07/wip/Objects/SplashImage.cs
@@ -1,4 +1,4 @@
-﻿using chapter_07.Objects.Base;
+﻿using chapter_07.Engine.Objects;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace chapter_07.Objects

--- a/chapter-07/wip/Objects/TerrainBackground.cs
+++ b/chapter-07/wip/Objects/TerrainBackground.cs
@@ -1,8 +1,6 @@
-﻿using chapter_07.Enum;
-using chapter_07.Objects.Base;
+﻿using chapter_07.Engine.Objects;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using System.Collections.Generic;
 
 namespace chapter_07.Objects
 {

--- a/chapter-07/wip/Program.cs
+++ b/chapter-07/wip/Program.cs
@@ -10,13 +10,16 @@ namespace chapter_07
     /// </summary>
     public static class Program
     {
+        private const int WIDTH = 1280;
+        private const int HEIGHT = 720;
+
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
         static void Main()
         {
-            using (var game = new MainGame(1280, 720, new SplashState()))
+            using (var game = new MainGame(WIDTH, HEIGHT, new SplashState()))
                 game.Run();
         }
     }

--- a/chapter-07/wip/Program.cs
+++ b/chapter-07/wip/Program.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using chapter_07.Engine;
+using chapter_07.States;
+using System;
 
 namespace chapter_07
 {
@@ -14,7 +16,7 @@ namespace chapter_07
         [STAThread]
         static void Main()
         {
-            using (var game = new MainGame())
+            using (var game = new MainGame(1280, 720, new SplashState()))
                 game.Run();
         }
     }

--- a/chapter-07/wip/States/Gameplay/GameplayEvents.cs
+++ b/chapter-07/wip/States/Gameplay/GameplayEvents.cs
@@ -1,0 +1,9 @@
+﻿using chapter_07.Engine.States;
+
+namespace chapter_07.States.Gameplay
+{
+    public class GameplayEvents : BaseGameStateEvent
+    {
+        public class PlayerShoots : GameplayEvents { }
+    }
+}

--- a/chapter-07/wip/States/Gameplay/GameplayInputCommand.cs
+++ b/chapter-07/wip/States/Gameplay/GameplayInputCommand.cs
@@ -1,4 +1,4 @@
-﻿using chapter_07.Input.Base;
+﻿using chapter_07.Engine.Input;
 
 namespace chapter_07.Input
 {

--- a/chapter-07/wip/States/Gameplay/GameplayInputMapper.cs
+++ b/chapter-07/wip/States/Gameplay/GameplayInputMapper.cs
@@ -1,4 +1,4 @@
-﻿using chapter_07.Input.Base;
+﻿using chapter_07.Engine.Input;
 using Microsoft.Xna.Framework.Input;
 using System.Collections.Generic;
 

--- a/chapter-07/wip/States/Gameplay/GameplayState.cs
+++ b/chapter-07/wip/States/Gameplay/GameplayState.cs
@@ -46,7 +46,7 @@ namespace chapter_07.States
             // load soundtracks into sound manager
             var track1 = LoadSound("FutureAmbient_1").CreateInstance();
             var track2 = LoadSound("FutureAmbient_2").CreateInstance();
-            _soundManager.AddSoundtrack(new List<SoundEffectInstance>() { track1, track2 });
+            _soundManager.SetSoundtrack(new List<SoundEffectInstance>() { track1, track2 });
         }
 
         public override void HandleInput(GameTime gameTime)

--- a/chapter-07/wip/States/Gameplay/GameplayState.cs
+++ b/chapter-07/wip/States/Gameplay/GameplayState.cs
@@ -49,13 +49,7 @@ namespace chapter_07.States
             // music
             var track1 = LoadSound("FutureAmbient_1").CreateInstance();
             var track2 = LoadSound("FutureAmbient_2").CreateInstance();
-            // TODO: move into sound manager
-            // _soundManager.AddSoundtrack(new List<SoundEffectInstance>() { track1, track2 }
-            _soundtracks = new List<SoundEffectInstance>() { track1, track2 };
-            
-            // set index to end because it'll switch to the next song, which is the 1st one.
-            // TODO: move into sound manager
-            _soundtrackIndex = _soundtracks.Count - 1;
+            _soundManager.AddSoundtrack(new List<SoundEffectInstance>() { track1, track2 });
         }
 
         public override void HandleInput(GameTime gameTime)
@@ -86,7 +80,7 @@ namespace chapter_07.States
             });
         }
 
-        public override void Update(GameTime gameTime)
+        public override void UpdateGameState(GameTime gameTime)
         {
             foreach (var bullet in _bulletList)
             {
@@ -116,29 +110,6 @@ namespace chapter_07.States
             }
 
             _bulletList = newBulletList;
-
-            // make sure we play the next track if the current one is over
-            // TODO: replace with sound manager
-            // _soundManager.PlaySoundtrack();
-            PlayMusic();
-        }
-        private void PlayMusic()
-        {
-            var nbTracks = _soundtracks.Count;
-            var currentTrack = _soundtracks[_soundtrackIndex];
-            var nextTrack =  _soundtracks[(_soundtrackIndex + 1) % nbTracks];
-
-            if (currentTrack.State == SoundState.Stopped)
-            {
-                nextTrack.Play();
-                _soundtrackIndex++;
-
-                if (_soundtrackIndex >= _soundtracks.Count)
-                {
-                    _soundtrackIndex = 0;
-                }
-            }
-
         }
  
         private void Shoot(GameTime gameTime)

--- a/chapter-07/wip/States/Gameplay/GameplayState.cs
+++ b/chapter-07/wip/States/Gameplay/GameplayState.cs
@@ -1,14 +1,11 @@
-﻿using chapter_07.Enum;
+﻿using chapter_07.Engine.Input;
+using chapter_07.Engine.States;
 using chapter_07.Input;
-using chapter_07.Input.Base;
 using chapter_07.Objects;
-using chapter_07.States.Base;
 
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Audio;
 using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Input;
-using Microsoft.Xna.Framework.Media;
 using System;
 using System.Collections.Generic;
 
@@ -52,11 +49,13 @@ namespace chapter_07.States
             // music
             var track1 = LoadSound("FutureAmbient_1").CreateInstance();
             var track2 = LoadSound("FutureAmbient_2").CreateInstance();
+            // TODO: move into sound manager
+            // _soundManager.AddSoundtrack(new List<SoundEffectInstance>() { track1, track2 }
             _soundtracks = new List<SoundEffectInstance>() { track1, track2 };
             
             // set index to end because it'll switch to the next song, which is the 1st one.
+            // TODO: move into sound manager
             _soundtrackIndex = _soundtracks.Count - 1;
-            PlayMusic();
         }
 
         public override void HandleInput(GameTime gameTime)
@@ -65,7 +64,7 @@ namespace chapter_07.States
             {
                 if (cmd is GameplayInputCommand.GameExit)
                 {
-                    NotifyEvent(Events.GAME_QUIT);
+                    NotifyEvent(new BaseGameStateEvent.GameQuit());
                 }
 
                 if (cmd is GameplayInputCommand.PlayerMoveLeft)
@@ -119,6 +118,8 @@ namespace chapter_07.States
             _bulletList = newBulletList;
 
             // make sure we play the next track if the current one is over
+            // TODO: replace with sound manager
+            // _soundManager.PlaySoundtrack();
             PlayMusic();
         }
         private void PlayMusic()
@@ -148,6 +149,8 @@ namespace chapter_07.States
                 _isShooting = true;
                 _lastShotAt = gameTime.TotalGameTime;
 
+                // TODO: trigger sound manager event and pass in event type
+                // _soundManager.PlaySound(Bullets);
                 _bulletSound.Play();
             }
         }

--- a/chapter-07/wip/States/Gameplay/GameplayState.cs
+++ b/chapter-07/wip/States/Gameplay/GameplayState.cs
@@ -2,6 +2,7 @@
 using chapter_07.Engine.States;
 using chapter_07.Input;
 using chapter_07.Objects;
+using chapter_07.States.Gameplay;
 
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Audio;
@@ -24,11 +25,6 @@ namespace chapter_07.States
 
         private List<BulletSprite> _bulletList;
 
-        private List<SoundEffectInstance> _soundtracks;
-        private int _soundtrackIndex = 0;
-
-        private SoundEffect _bulletSound;
-
         public override void LoadContent()
         {
             _playerSprite = new PlayerSprite(LoadTexture(PlayerFighter));
@@ -43,10 +39,11 @@ namespace chapter_07.States
             var playerYPos = _viewportHeight - _playerSprite.Height - 30;
             _playerSprite.Position = new Vector2(playerXPos, playerYPos);
 
-            // sound effects
-            _bulletSound = LoadSound("bulletSound");
+            // load sound effects and register in the sound manager
+            var bulletSound = LoadSound("bulletSound");
+            _soundManager.RegisterSound(new GameplayEvents.PlayerShoots(), bulletSound);
 
-            // music
+            // load soundtracks into sound manager
             var track1 = LoadSound("FutureAmbient_1").CreateInstance();
             var track2 = LoadSound("FutureAmbient_2").CreateInstance();
             _soundManager.AddSoundtrack(new List<SoundEffectInstance>() { track1, track2 });
@@ -120,9 +117,7 @@ namespace chapter_07.States
                 _isShooting = true;
                 _lastShotAt = gameTime.TotalGameTime;
 
-                // TODO: trigger sound manager event and pass in event type
-                // _soundManager.PlaySound(Bullets);
-                _bulletSound.Play();
+                NotifyEvent(new GameplayEvents.PlayerShoots());
             }
         }
 

--- a/chapter-07/wip/States/Splash/SplashInputCommand.cs
+++ b/chapter-07/wip/States/Splash/SplashInputCommand.cs
@@ -1,4 +1,4 @@
-﻿using chapter_07.Input.Base;
+﻿using chapter_07.Engine.Input;
 
 namespace chapter_07.Input
 {

--- a/chapter-07/wip/States/Splash/SplashInputMapper.cs
+++ b/chapter-07/wip/States/Splash/SplashInputMapper.cs
@@ -1,4 +1,4 @@
-﻿using chapter_07.Input.Base;
+﻿using chapter_07.Engine.Input;
 using Microsoft.Xna.Framework.Input;
 using System.Collections.Generic;
 

--- a/chapter-07/wip/States/Splash/SplashState.cs
+++ b/chapter-07/wip/States/Splash/SplashState.cs
@@ -2,8 +2,7 @@
 using chapter_07.Engine.States;
 using chapter_07.Input;
 using chapter_07.Objects;
-
-using System.Collections.Generic;
+using Microsoft.Xna.Framework;
 
 namespace chapter_07.States
 {
@@ -24,6 +23,8 @@ namespace chapter_07.States
                 }
             });
         }
+
+        public override void UpdateGameState(GameTime _) { }
 
         protected override void SetInputManager()
         {

--- a/chapter-07/wip/States/Splash/SplashState.cs
+++ b/chapter-07/wip/States/Splash/SplashState.cs
@@ -1,8 +1,7 @@
-﻿using chapter_07.Enum;
+﻿using chapter_07.Engine.Input;
+using chapter_07.Engine.States;
 using chapter_07.Input;
-using chapter_07.Input.Base;
 using chapter_07.Objects;
-using chapter_07.States.Base;
 
 using System.Collections.Generic;
 

--- a/chapter-07/wip/chapter-07.csproj
+++ b/chapter-07/wip/chapter-07.csproj
@@ -44,6 +44,7 @@
     <Compile Include="Engine\Input\BaseInputMapper.cs" />
     <Compile Include="Engine\Input\BaseInputCommand.cs" />
     <Compile Include="Engine\Input\InputManager.cs" />
+    <Compile Include="Engine\Sound\SoundManager.cs" />
     <Compile Include="States\Gameplay\GameplayEvents.cs" />
     <Compile Include="States\Gameplay\GameplayInputCommand.cs" />
     <Compile Include="States\Gameplay\GameplayInputMapper.cs" />
@@ -76,9 +77,7 @@
     <MonoGameContentReference Include="Content\Content.mgcb" />
     <None Include="app.manifest" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Engine\Sound\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildExtensionsPath)\MonoGame\v3.0\MonoGame.Content.Builder.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/chapter-07/wip/chapter-07.csproj
+++ b/chapter-07/wip/chapter-07.csproj
@@ -41,25 +41,26 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="Enum\Events.cs" />
-    <Compile Include="Input\Base\BaseInputMapper.cs" />
-    <Compile Include="Input\Base\BaseInputCommand.cs" />
-    <Compile Include="Input\Base\InputManager.cs" />
-    <Compile Include="Input\GameplayInputCommand.cs" />
-    <Compile Include="Input\GameplayInputMapper.cs" />
-    <Compile Include="Input\SplashInputCommand.cs" />
-    <Compile Include="Input\SplashInputMapper.cs" />
-    <Compile Include="MainGame.cs" />
-    <Compile Include="Objects\Base\BaseGameObject.cs" />
+    <Compile Include="Engine\Input\BaseInputMapper.cs" />
+    <Compile Include="Engine\Input\BaseInputCommand.cs" />
+    <Compile Include="Engine\Input\InputManager.cs" />
+    <Compile Include="States\Gameplay\GameplayEvents.cs" />
+    <Compile Include="States\Gameplay\GameplayInputCommand.cs" />
+    <Compile Include="States\Gameplay\GameplayInputMapper.cs" />
+    <Compile Include="States\Splash\SplashInputCommand.cs" />
+    <Compile Include="States\Splash\SplashInputMapper.cs" />
+    <Compile Include="Engine\MainGame.cs" />
+    <Compile Include="Engine\Objects\BaseGameObject.cs" />
     <Compile Include="Objects\BulletSprite.cs" />
     <Compile Include="Objects\PlayerSprite.cs" />
     <Compile Include="Objects\SplashImage.cs" />
     <Compile Include="Objects\TerrainBackground.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="States\Base\BaseGameState.cs" />
-    <Compile Include="States\GameplayState.cs" />
-    <Compile Include="States\SplashState.cs" />
+    <Compile Include="Engine\States\BaseGameState.cs" />
+    <Compile Include="Engine\States\BaseGameStateEvent.cs" />
+    <Compile Include="States\Gameplay\GameplayState.cs" />
+    <Compile Include="States\Splash\SplashState.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MonoGame.Framework">
@@ -75,7 +76,9 @@
     <MonoGameContentReference Include="Content\Content.mgcb" />
     <None Include="app.manifest" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Engine\Sound\" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildExtensionsPath)\MonoGame\v3.0\MonoGame.Content.Builder.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Add new sound manager that can play soundtracks and sound effects based on game events.

Refactoring:

- Move engine code into its own dir and namespace
- Fully genericize MainGame and moved into the engine. Now needs to know which game state class to run first upon initialization. That was the only thing that kept it tied to concrete game code.
- Replace the Events enum with classes
- Organize game code (non-engine) by game state. All code related to GameplayState is in the same dir. It's more cohesive this way.