### PR TITLE
Generate lifespans within the given range

### DIFF
--- a/chapter-08/end/Engine/Particles/EmitterParticleState.cs
+++ b/chapter-08/end/Engine/Particles/EmitterParticleState.cs
@@ -32,9 +32,7 @@ namespace chapter_08.Engine.Particles.EmitterTypes
 
         public int GenerateLifespan()
         {
-            var range = MaxLifespan - MinLifespan;
-            var randomAge = _rnd.NextRandom() * range;
-            return MinLifespan + randomAge;
+            return _rnd.NextRandom(MinLifespan, MaxLifespan);
         }
 
         public float GenerateVelocity()


### PR DESCRIPTION
The previous version of this code generated lifespans way out of range. After a few seconds, all active particles had lifespands in the million range and particles lived so long all their opacities were reduce to close enough to zero to be invisible, but still alive so the emitter wasn't allowed to create any new ones.